### PR TITLE
Add .editorconfig and violating C# example

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+dotnet_sort_system_directives_first = true
+csharp_new_line_before_open_brace = all
+csharp_prefer_braces = true
+csharp_style_var_for_built_in_types = false
+csharp_style_expression_bodied_methods = false

--- a/Example.cs
+++ b/Example.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System;
+
+namespace Example {
+class Program {
+		static void Main(string[] args) {
+			var count = 10;
+			var name = "hello";
+
+			if (count > 5)
+				Console.WriteLine(name);
+
+			var items = new List<string>() { "a", "b", "c" };
+
+			string Greet(string n) => $"Hello, {n}!";
+
+			Console.WriteLine(Greet(name));
+		}
+}
+}


### PR DESCRIPTION
## Summary
- Adds a `.editorconfig` with rules for indentation (spaces, size 4), brace placement, `var` usage, and expression-bodied members for C# files
- Adds `Example.cs` that intentionally violates those rules (tabs, same-line braces, missing braces, `var` for built-in types, expression-bodied methods)

## Test plan
- [ ] Verify `.editorconfig` is recognized by your editor/IDE
- [ ] Open `Example.cs` and confirm editor warnings for the intentional violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)